### PR TITLE
Quick change to avoid a crash on startup

### DIFF
--- a/modules/reply.py
+++ b/modules/reply.py
@@ -2,7 +2,6 @@ import re
 import json
 import discord
 from modules.module import Module
-from utilities import utils
 from config import stampy_youtube_channel_id, youtube_testing_thread_url
 from datetime import datetime
 
@@ -139,7 +138,7 @@ class Reply(Module):
             question_user = match.group(1)  # YouTube user (.*) asked this question
 
         video_url, comment_id = question_url.split("&lc=")
-        video_titles = utils.get_title(video_url)
+        video_titles = self.utils.get_title(video_url)
         if not video_titles:
             # this should actually only happen in dev
             video_titles = ["Video Title Unknown", "Video Title Unknown"]
@@ -149,7 +148,7 @@ class Reply(Module):
 
         answer_time = datetime.now() # How should this be formated?
 
-        utils.wiki.add_answer(answer_title, approvers, answer_time, reply_message, question_display_title + " id:" + comment_id)
+        self.utils.wiki.add_answer(answer_title, approvers, answer_time, reply_message, question_display_title + " id:" + comment_id)
         ##
 
         self.post_reply(reply_message, question_id)

--- a/utilities.py
+++ b/utilities.py
@@ -426,6 +426,3 @@ def get_memory_usage():
     bytes_used = int(process.memory_info().rss) / 1000000
     megabytes_string = f"{bytes_used:,.2f} MegaBytes"
     return "I'm using %s bytes of memory" % megabytes_string
-    
-
-utils = Utilities.get_instance()


### PR DESCRIPTION
utils = Utilities.get_instance() was deleted by a recent commit, but some modules still attempt to import it. Temporarily added the line back until that is no longer the case 