### PR TITLE
Make the stamp requirement for posting comments a fraction of total s…

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,6 +25,9 @@ plex_id = "756254556811165756"
 god_id = "0"
 youtube_testing_thread_url = "https://www.youtube.com/watch?v=vuYtSDMBLtQ&lc=Ugx2FUdOI6GuxSBkOQd4AaABAg"
 
+# Multiply this by the total number of votes made, to get the number of stamps needed to post a reply comment
+comment_posting_threshold_factor = 0.15
+
 discord_token_env_variable = "DISCORD_TOKEN"
 discord_guild_env_variable = "DISCORD_GUILD"
 youtube_api_key_env_variable = "YOUTUBE_API_KEY"


### PR DESCRIPTION
…tamps, not just 30

Maybe it would be nice if Stampy remembered how many stamps he _said_ a particular reply would need, and stick to that, rather than that number shifting slightly every time more votes happen. But I think that's more effort than it's worth. And maybe it's funny that his standards keep very slightly rising.

I hope the slight change doesn't break the integration test.