### PR TITLE
hotfixed unanswered question after changes to wiki user pages

### DIFF
--- a/api/semanticwiki.py
+++ b/api/semanticwiki.py
@@ -265,7 +265,7 @@ class SemanticWiki(Persistence):
             else:
                 question["url"] = "No URL"
             if relevant_vals["Asker"]:
-                question["username"] = relevant_vals["Asker"][0]["fulltext"]
+                question["username"] = relevant_vals["Asker"][0]
             else:
                 question["username"] = "Unknown"
             if relevant_vals["Video"]:


### PR DESCRIPTION
relevant_vals["Asker"][0] used to contain a page dict, now only contains a string with the contents that used to be in the ["fulltext"] field. The single line where this was used was changed to reflect this.