### PR TITLE
Changed reboot to require message author to have the bot admin role.

### DIFF
--- a/modules/StampyControls.py
+++ b/modules/StampyControls.py
@@ -51,7 +51,8 @@ class StampyControls(Module):
     @staticmethod
     async def reboot(message):
         if hasattr(message.channel, "name") and message.channel.name in stampy_control_channel_names:
-            if message.author.id == rob_id:
+            asked_by_admin = discord.utils.get(message.author.roles, name="bot admin")
+            if asked_by_admin:
                 await message.channel.send("Rebooting...")
                 sys.stdout.flush()
                 exit()


### PR DESCRIPTION
Per office hours, reboot will now require the bot admin role instead of being Rob.

Closes #80 