### PR TITLE
OpenAI safety modifications

### DIFF
--- a/modules/gpt3module.py
+++ b/modules/gpt3module.py
@@ -241,6 +241,7 @@ class GPT3Module(Module):
                 top_p=1,
                 # stop=["\n"],
                 logit_bias=logit_bias,
+                user=str(message.author.id),
             )
         except openai.error.AuthenticationError:
             print("OpenAI Authentication Failed")
@@ -283,6 +284,7 @@ class GPT3Module(Module):
                     temperature=0,
                     max_tokens=100,
                     top_p=1,
+                    user=str(message.author.id),
                     # stop=["\n"],
                 )
             except openai.error.AuthenticationError:


### PR DESCRIPTION
Two new 'safety' features: Checking with the content filter that a prompt is ok before allowing GPT3 to respond, and sending the user id of the person talking to stampy with each api request