### PR TITLE
add rate_limit and tick functions

### DIFF
--- a/modules/module.py
+++ b/modules/module.py
@@ -141,6 +141,16 @@ class Module(object):
         Use this to allow modules to handle adding and removing reactions on messages"""
         return Response()
 
+    async def tick(self):
+        """This function will be called all the time, whenever anything happens on the discord.
+        Use it for things that need to happen regularly, but RATE LIMIT IT!
+        ALWAYS call self.utils.rate_limit() first thing in the function, so it doesn't happen too much.
+        For example:
+
+        if self.utils.rate_limit("check youtube API", seconds=30):
+            return"""
+        pass
+
     def __str__(self):
         return "Base Module"
 


### PR DESCRIPTION
This could be pulled in now. It could also be thought of as incomplete, since there are places in the code where the old cooldown pattern is still being used.
This change should allow all the youtube comment polling stuff to live in a module, and have utilities have less specific functionality in it