### PR TITLE
Automaticmodules

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -22,6 +22,6 @@ import_all_modules()
 
 # USAGE:
 # with this, any file can call "import modules" and all of the modules in this folder will be imported
-# once all modules are imported, you can use "Module.__subclasses__()" to get a list of all modules.
+# once all modules are imported, you can use "modules.Module.__subclasses__()" to get a list of all modules.
 
 


### PR DESCRIPTION
modified init of modules to automatically import all modules in that folder. 
With this you can do:
> import modules
and
> modules.Module.__subclasses__()
to fetch a list of all Module classes without needing a hardcoded list

This PR doesnt change any existing code to make use of this option. 