### PR TITLE
Fix page movers

### DIFF
--- a/api/semanticwiki.py
+++ b/api/semanticwiki.py
@@ -430,6 +430,10 @@ class SemanticWiki(Persistence):
 
             message = f"Page offset {index + offset}/{max_offset}: <{item['fullurl']}>\n" f"```js\n"
             try:
+                if item["displaytitle"] == "":
+                    message += f"  WARNING: page `{page}` doesn't have a display title => skipping```\n"
+                    yield message
+                    continue
                 new_page = self.new_title_with_id(page, item["displaytitle"])
                 new_page_already_exists = (
                     page == new_page or "title" in self.get_page(new_page)["query"]["pages"][0].values()


### PR DESCRIPTION
Fixed #138 

The first page in the queue is broken for some reason, but it looks like it's on the wiki side of things.  The error reporting was also broken, unfortunately.  I fixed the error reporting and added a check to not crash if this error on the wiki comes up again.