### PR TITLE
Wiki Stamps Update

### DIFF
--- a/modules/stampcollection.py
+++ b/modules/stampcollection.py
@@ -274,30 +274,28 @@ class StampsModule(Module):
                 else:
                     return Response(confidence=10, text=self.UNAUTHORIZED_MESSAGE, args=[message])
 
-        if self.utils.stampy_is_author(message):  # not sure how to send as stampy to test, but presumably this works
-            # Have tested the rest of this and it adds/removes stamps correctly
-
-            text = message.clean_content
-            if re.match(r"[0-9]+.+stamped.+", text):
-                users = re.findall(r"[0-9]+", text)
-                from_id = int(users[0])
-                to_id = int(users[1])
-                stamps_before_update = self.get_user_stamps(to_id)
-                emoji = "stamp"
-                negative = False
-                if re.match(r"[0-9]+.+unstamped.+", text):
-                    negative = True
-
-                self.update_vote(emoji, from_id, to_id, negative=negative)
-                self.log.info(
-                    self.class_name,
-                    reaction_message_author_id=to_id,
-                    stamps_before_update=stamps_before_update,
-                    stamps_after_update=self.get_user_stamps(to_id),
-                    negative_reaction=negative,
-                )
-
         return Response()
+
+    def process_message_from_stampy(self, message):
+        text = message.clean_content
+        if re.match(r"[0-9]+.+stamped.+", text):
+            users = re.findall(r"[0-9]+", text)
+            from_id = int(users[0])
+            to_id = int(users[1])
+            stamps_before_update = self.get_user_stamps(to_id)
+            emoji = "stamp"
+            negative = False
+            if re.match(r"[0-9]+.+unstamped.+", text):
+                negative = True
+
+            self.update_vote(emoji, from_id, to_id, negative=negative)
+            self.log.info(
+                self.class_name,
+                reaction_message_author_id=to_id,
+                stamps_before_update=stamps_before_update,
+                stamps_after_update=self.get_user_stamps(to_id),
+                negative_reaction=negative,
+            )
 
     async def reloadallstamps(self, message):
         self.log.info(self.class_name, ALERT="FULL STAMP HISTORY RESET BAYBEEEEEE")


### PR DESCRIPTION
Added functionality for Stampy to count the stamp messages from the Wiki in the wiki-feed channel (it actually just matches the message format and checks it is from stampy, rather than looking specifically in the wiki-feed channel) -- right now all wiki stamps are just a stamp emoji, not sure if we want to calculate them differently.

I also removed what I believe is a dupliate call to add_vote when stampy processes reactions.