### PR TITLE
Updated query for unasked questions to reflect wiki changes

### DIFF
--- a/api/semanticwiki.py
+++ b/api/semanticwiki.py
@@ -296,7 +296,7 @@ class SemanticWiki(Persistence):
 
     def get_unasked_wiki_question(self, sort, order):
         query = (
-            "[[Category:Unanswered questions]][[AskedOnDiscord::f]][[Origin::Wiki]][[ForRob::!true]]|?Question|"
+            "[[AnsweredStatus::Unanswered]][[AskedOnDiscord::f]][[Origin::Wiki]][[ForRob::!true]]|?Question|"
             + "?asker|?AskDate|?AskedOnDiscord|sort=AskedOnDiscord,{0}|limit=1|order=asc,{1}".format(
                 sort, order
             )


### PR DESCRIPTION
We changed the UnaskedQuestions from a category to a property, and broke the query. This updates the query to use the property.