### PR TITLE
added soft requirement for wiki questions to be canonical

### DIFF
--- a/api/semanticwiki.py
+++ b/api/semanticwiki.py
@@ -296,8 +296,9 @@ class SemanticWiki(Persistence):
 
     def get_unasked_wiki_question(self, sort, order):
         query = (
-            "[[AnsweredStatus::Unanswered]][[AskedOnDiscord::f]][[Origin::Wiki]][[ForRob::!true]]|?Question|"
-            + "?asker|?AskDate|?AskedOnDiscord|sort=AskedOnDiscord,{0}|limit=1|order=asc,{1}".format(
+            "[[AnsweredStatus::Unanswered]][[Origin::Wiki]][[ForRob::!true]]|?Question|"
+            + "?asker|?AskDate|?AskedOnDiscord |?Canonical"
+            + "|sort=AskedOnDiscord,Canonical,{0}|limit=1|order=asc,asc,{1}".format(
                 sort, order
             )
         )


### PR DESCRIPTION
meaning that canonical questions will always be shown before non-canonicals, but if all canonicals have been asked it will continue on to non canonicals (right now there are enough canonicals left that it makes no difference, but the soft requirement is better for the future)