### PR TITLE
Moved Services Enum to Config to prevent circular import

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,5 @@
 from api.utilities.gooseutils import GooseAIEngines
-from utilities.serviceutils import Services
+from enum import Enum
 import dotenv
 import os
 
@@ -15,6 +15,25 @@ def getenv(env_var, default=None):
     if value is None:
         raise Exception(f"Environment Variable '{env_var}' not set and no default provided")
     return value
+
+
+class Services(Enum):
+    DISCORD = "Discord"
+    FLASK = "Flask"
+    SLACK = "Slack"
+
+    def __str__(self) -> None:
+        return str(self._value_)
+
+    def __eq__(self, other: object) -> bool:
+        try:
+            return str(self) == str(other)
+        except Exception:
+            return False
+
+    def __hash__(self):
+
+        return hash(str(self)) >> 22
 
 
 maximum_recursion_depth = 30

--- a/modules/StampyControls.py
+++ b/modules/StampyControls.py
@@ -1,9 +1,8 @@
 import sys
 import discord
 from modules.module import Module, Response
-from config import stampy_control_channel_names, TEST_RESPONSE_PREFIX
+from config import stampy_control_channel_names, TEST_RESPONSE_PREFIX, Services
 from utilities import Utilities, get_github_info, get_memory_usage, get_running_user_info, get_question_id
-from utilities.serviceutils import Services
 
 
 class StampyControls(Module):

--- a/modules/invitemanager.py
+++ b/modules/invitemanager.py
@@ -1,8 +1,7 @@
 import re
 import discord
-from config import rob_id
+from config import rob_id, Services
 from modules.module import Module, Response
-from utilities.serviceutils import Services
 
 
 class InviteManager(Module):

--- a/modules/stampcollection.py
+++ b/modules/stampcollection.py
@@ -4,10 +4,8 @@ import numpy as np
 from utilities import utilities
 from modules.module import Module, Response
 from config import rob_id, god_id, stampy_id
-from config import stamp_scores_csv_file_path
-
+from config import stamp_scores_csv_file_path, Services
 from utilities.discordutils import DiscordMessage
-from utilities.serviceutils import Services
 
 
 class StampsModule(Module):

--- a/modules/testModule.py
+++ b/modules/testModule.py
@@ -1,10 +1,9 @@
 import re
 from asyncio import sleep
 from utilities import get_question_id, is_test_response
-from utilities.serviceutils import Services
 from modules.module import Module, Response
 from jellyfish import jaro_winkler_similarity
-from config import TEST_QUESTION_PREFIX, TEST_RESPONSE_PREFIX, test_response_message
+from config import TEST_QUESTION_PREFIX, TEST_RESPONSE_PREFIX, test_response_message, Services
 
 
 class TestModule(Module):

--- a/stam.py
+++ b/stam.py
@@ -5,7 +5,6 @@ from servicemodules.discord import DiscordHandler
 from servicemodules.slack import SlackHandler
 from servicemodules.flask import FlaskHandler
 from utilities import Utilities
-from utilities.serviceutils import Services
 from structlog import get_logger
 from modules.module import Module
 from config import (
@@ -13,6 +12,7 @@ from config import (
     prod_local_path,
     ENVIRONMENT_TYPE,
     acceptable_environment_types,
+    Services,
 )
 
 log_type = "stam.py"

--- a/utilities/serviceutils.py
+++ b/utilities/serviceutils.py
@@ -1,25 +1,8 @@
+from config import Services
 from datetime import datetime, timezone
 from typing import Optional
 from enum import Enum
 
-
-class Services(Enum):
-    DISCORD = "Discord"
-    FLASK = "Flask"
-    SLACK = "Slack"
-
-    def __str__(self) -> None:
-        return str(self._value_)
-
-    def __eq__(self, other: object) -> bool:
-        try:
-            return str(self) == str(other)
-        except Exception:
-            return False
-
-    def __hash__(self):
-
-        return hash(str(self)) >> 22
 
 class ServiceRole:
     def __init__(self, name: str, id: str):


### PR DESCRIPTION
Fixes deployment:
```
Traceback (most recent call last):
err:   File "/home/***/miniconda3/envs/stampy/lib/python3.9/runpy.py", line 197, in _run_module_as_main
err:     return _run_code(code, main_globals, None,
err:   File "/home/***/miniconda3/envs/stampy/lib/python3.9/runpy.py", line 87, in _run_code
err:     exec(code, run_globals)
err:   File "/home/***/stampy/scripts/notify-discord-stampy-offline.py", line 4, in <module>
err:     from config import bot_dev_channel_id, discord_token
err:   File "/home/***/stampy/config.py", line 2, in <module>
err:     from utilities.serviceutils import Services
err:   File "/home/***/stampy/utilities/__init__.py", line 1, in <module>
err:     from utilities import utilities as util
err:   File "/home/***/stampy/utilities/utilities.py", line 2, in <module>
err:     from config import (
err: ImportError: cannot import name 'youtube_api_version' from partially initialized module 'config' (most likely due to a circular import) 
```