### PR TITLE
Setting Stampy back to old wiki.

### DIFF
--- a/api/semanticwiki.py
+++ b/api/semanticwiki.py
@@ -390,10 +390,10 @@ class SemanticWiki(Persistence):
         return response
 
     def get_question_count(self):
-        query = "[[Wiki:API Queries]]|?UnaskedQuestions"
+        query = "[[Meta:API Queries]]|?UnaskedQuestions"
         results = self.ask(query)
 
-        return results["Wiki:API Queries"]["printouts"]["UnaskedQuestions"][0]
+        return results["Meta:API Queries"]["printouts"]["UnaskedQuestions"][0]
 
     @staticmethod
     def new_title_with_id(old_title: str, new_title: str):

--- a/config.py
+++ b/config.py
@@ -102,7 +102,7 @@ wolfram_token = getenv("WOLFRAM_TOKEN", default="null")
 slack_app_token = getenv("SLACK_APP_TOKEN", default="null")
 slack_bot_token = getenv("SLACK_BOT_TOKEN", default="null")
 
-wiki_config = {"uri": "https://wiki.stampy.ai/w/api.php", "user": "Stampy@stampy", "password": wiki_password}
+wiki_config = {"uri": "https://stampy.ai/w/api.php", "user": "Stampy@stampy", "password": wiki_password}
 
 
 stampy_control_channel_names = [


### PR DESCRIPTION
Apparently, wiki.stampy.ai is not ready for production, undoing #176 #179.

Requested by @plexish 