### PR TITLE
Deprecate trello references from README and TUTORIAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ stampy from the test discord server and see the messages in your terminal.
 
 # How to Contribute
 
-Checkout the [Trello](https://trello.com/b/LBmYgkes/stampy). It's a great place to start. Make sure to attach your name to the card you're going to work on and then move it into the progress lane. Currently, there are still many setup and organizational tasks. In the future, we would mostly want Stampy contributions to be in the form of adding new modules.
+Check out the currently open github issues and pull requests, if you see something open you can help out with add a comment. Most coordinations is done through live voice calls in the discord.
+There's a [Trello](https://trello.com/b/LBmYgkes/stampy) you can request access to, but it's not very updated.
 
 If you make a change to source code, please create a new branch first, then commit your changes there. Open a pull request on github and ask for other developers to review your code before merging.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -15,8 +15,8 @@ To explain how to implement a new Stampy feature, let's work through an example:
 # Module Creation Steps
 We'll implement this by creating a new module, which we'll call the 'choose' module. Here's how you'd do that!
 
-1. Create a card on the [trello](https://trello.com/b/LBmYgkes/stampy) in the "Ideas" List, that describes the module that you are planning to make.
-1. Message the [`#stampy-dev` channel on Discord](https://discord.com/channels/677546901339504640/758062805810282526) with the card, to get feedback and buy-in for your potential module. If the general idea seems well liked, move the card into the "Doing" lane and add your name to the card.
+1. Open a GitHub issue that describes the module that you're planning to make.
+1. Message the [`#stampy-dev` channel on Discord](https://discord.com/channels/677546901339504640/758062805810282526), to get feedback and buy-in for your potential module. If the general idea seems well liked, assign it to yourself and start coding.
 1. Create a new branch named similarly to your module. `$ git checkout -b choose-module`
 1. Create a new file named after your module inside of [the `modules` folder](https://github.com/robertskmiles/stampy/tree/master/modules). `$ <editor of your choice> choose.py`
 1. Inside of `choose.py`, create a child class of the `Module` class


### PR DESCRIPTION
The trello is apparently outdated, so suggesting it as the primary means of contributing is misleading. Could consider removing the reference to it completely.

I'm also not sure of your workflow and semi-guessed, so feel free to suggest as many changes as you want.