### PR TITLE
Id refactor

### DIFF
--- a/api/openai.py
+++ b/api/openai.py
@@ -1,7 +1,9 @@
 from api.utilities.openai import OpenAIEngines
-from config import openai_channels, openai_api_key, rob_id
+from config import openai_api_key
 from structlog import get_logger
-from utilities.serviceutils import Services, ServiceMessage
+from servicemodules.discordConstants import rob_id
+from servicemodules.serviceConstants import Services, openai_channel_ids
+from utilities.serviceutils import ServiceMessage
 from utilities import utilities, Utilities
 import openai
 import discord
@@ -17,17 +19,11 @@ class OpenAI:
         super().__init__()
         self.class_name = self.__class__.__name__
         self.log = get_logger()
-        self.allowed_channels: dict[Services, list[str]] = {}
-        for channel, service in openai_channels:
-            if service not in self.allowed_channels:
-                self.allowed_channels[service] = [channel]
-            else:
-                self.allowed_channels[service].append(channel)
 
     def is_channel_allowed(self, message: ServiceMessage) -> bool:
-        if message.service not in self.allowed_channels:
+        if message.service not in openai_channel_ids:
             return False
-        return message.channel.name in self.allowed_channels[message.service]
+        return message.channel.id in openai_channel_ids[message.service]
 
     def cf_risk_level(self, prompt):
         """Ask the openai content filter if the prompt is risky

--- a/config.py
+++ b/config.py
@@ -1,5 +1,4 @@
 from api.utilities.gooseutils import GooseAIEngines
-from enum import Enum
 import dotenv
 import os
 
@@ -18,33 +17,10 @@ def getenv(env_var, default=NOT_PROVIDED):
     return value
 
 
-class Services(Enum):
-    DISCORD = "Discord"
-    FLASK = "Flask"
-    SLACK = "Slack"
-
-    def __str__(self) -> None:
-        return str(self._value_)
-
-    def __eq__(self, other: object) -> bool:
-        try:
-            return str(self) == str(other)
-        except Exception:
-            return False
-
-    def __hash__(self):
-
-        return hash(str(self)) >> 22
-
-
 maximum_recursion_depth = 30
 subs_dir = "./database/subs"
 youtube_api_service_name = "youtube"
 youtube_api_version = "v3"
-rob_id = 181142785259208704
-stampy_id = "736241264856662038"
-wikifeed_id = "819348549820088350"
-plex_id = "756254556811165756"
 god_id = "0"
 youtube_testing_thread_url = "https://www.youtube.com/watch?v=vuYtSDMBLtQ&lc=Ugx2FUdOI6GuxSBkOQd4AaABAg"
 
@@ -81,15 +57,11 @@ stampy_youtube_channel_id = {
     "development": "DvKrlpIXM0BGYLD2jjLGvg",
 }[ENVIRONMENT_TYPE]
 
-bot_dev_channel_id = {"production": 808138366330994688, "development": 803448149946662923}[ENVIRONMENT_TYPE] # TODO: the id is for talk-to-stampy, does the var name need to change, or does the id (correct is 758062805810282526//817518145472299009)
-error_channel_id = {"production": 1017527224540344380, "development": 1017531179664150608}[ENVIRONMENT_TYPE]
-
 stamp_scores_csv_file_path = {
     "production": "/var/www/html/stamps-export.csv",
     "development": "stamps-export.csv",
 }[ENVIRONMENT_TYPE]
 
-# admin_usernames = ["robertskmiles", "sudonym"]
 
 discord_token = getenv("DISCORD_TOKEN")
 discord_guild = getenv("DISCORD_GUILD")
@@ -106,16 +78,6 @@ slack_bot_token = getenv("SLACK_BOT_TOKEN", default=None)
 wiki_config = {"uri": "https://stampy.ai/w/api.php", "user": "Stampy@stampy", "password": wiki_password}
 
 
-stampy_control_channel_ids = (
-    {"production": -1, "development": 803448149946662923}[ENVIRONMENT_TYPE],  # test
-    {"production": 736247813616304159, "development": 817518389848309760}[ENVIRONMENT_TYPE],  # stampy-dev-priv
-    {"production": 758062805810282526, "development": 817518145472299009}[ENVIRONMENT_TYPE],  # stampy-dev
-    {"production": 758062805810282526, "development": 817518440192409621}[ENVIRONMENT_TYPE],  # talk-to-stampy
-    {"production": -1, "development": 736241264856662038}[ENVIRONMENT_TYPE],  # robertskmiles TODO: replace -1 with the id for robs DM with stampy,
-)
-bot_admin_role_id = {"production": 819898114823159819, "development": 948709263461711923}[ENVIRONMENT_TYPE]
-
-
 goose_engine_fallback_order = [  # What engine to use in order of preference in case one goes down.
     GooseAIEngines.GPT_20B,
     GooseAIEngines.GPT_6B,
@@ -128,25 +90,3 @@ goose_engine_fallback_order = [  # What engine to use in order of preference in 
     GooseAIEngines.FAIRSEQ_1_3B,
     GooseAIEngines.FAIRSEQ_125M,
 ]
-
-
-openai_channels: list[tuple[str, Services]] = [  # What channels may use openai.
-    ("stampy-dev-priv", Services.DISCORD),
-    ("aligned-intelligences-only", Services.DISCORD),
-    ("ai", Services.DISCORD),
-    ("not-ai", Services.DISCORD),
-    ("events", Services.DISCORD),
-    ("projects", Services.DISCORD),
-    ("book-club", Services.DISCORD),
-    ("dialogues-with-stampy", Services.DISCORD),
-    ("meta", Services.DISCORD),
-]
-
-
-service_italics_marks = {
-    Services.SLACK: "_",
-    Services.FLASK: "",
-}
-
-
-default_italics_mark = "*"

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ stampy_youtube_channel_id = {
     "development": "DvKrlpIXM0BGYLD2jjLGvg",
 }[ENVIRONMENT_TYPE]
 
-bot_dev_channel_id = {"production": 808138366330994688, "development": 803448149946662923}[ENVIRONMENT_TYPE]
+bot_dev_channel_id = {"production": 808138366330994688, "development": 803448149946662923}[ENVIRONMENT_TYPE] # TODO: the id is for talk-to-stampy, does the var name need to change, or does the id (correct is 758062805810282526//817518145472299009)
 error_channel_id = {"production": 1017527224540344380, "development": 1017531179664150608}[ENVIRONMENT_TYPE]
 
 stamp_scores_csv_file_path = {
@@ -89,7 +89,7 @@ stamp_scores_csv_file_path = {
     "development": "stamps-export.csv",
 }[ENVIRONMENT_TYPE]
 
-admin_usernames = ["robertskmiles", "sudonym"]
+# admin_usernames = ["robertskmiles", "sudonym"]
 
 discord_token = getenv("DISCORD_TOKEN")
 discord_guild = getenv("DISCORD_GUILD")
@@ -106,13 +106,14 @@ slack_bot_token = getenv("SLACK_BOT_TOKEN", default=None)
 wiki_config = {"uri": "https://stampy.ai/w/api.php", "user": "Stampy@stampy", "password": wiki_password}
 
 
-stampy_control_channel_names = [
-    "test",
-    "stampy-dev-priv",
-    "stampy-dev",
-    "talk-to-stampy",
-    "robertskmiles",
-]
+stampy_control_channel_ids = (
+    {"production": -1, "development": 803448149946662923}[ENVIRONMENT_TYPE],  # test
+    {"production": 736247813616304159, "development": 817518389848309760}[ENVIRONMENT_TYPE],  # stampy-dev-priv
+    {"production": 758062805810282526, "development": 817518145472299009}[ENVIRONMENT_TYPE],  # stampy-dev
+    {"production": 758062805810282526, "development": 817518440192409621}[ENVIRONMENT_TYPE],  # talk-to-stampy
+    {"production": -1, "development": 736241264856662038}[ENVIRONMENT_TYPE],  # robertskmiles TODO: replace -1 with the id for robs DM with stampy,
+)
+bot_admin_role_id = {"production": 819898114823159819, "development": 948709263461711923}[ENVIRONMENT_TYPE]
 
 
 goose_engine_fallback_order = [  # What engine to use in order of preference in case one goes down.

--- a/modules/Factoids.py
+++ b/modules/Factoids.py
@@ -1,7 +1,7 @@
 import re
 import random
 import sqlite3
-from config import rob_id
+from servicemodules.discordConstants import rob_id
 from modules.module import Module, Response
 
 

--- a/modules/Factoids.py
+++ b/modules/Factoids.py
@@ -1,7 +1,7 @@
 import re
 import random
 import sqlite3
-from servicemodules.discordConstants import rob_id
+from servicemodules.discordConstants import rob_id, bot_dev_role_id
 from modules.module import Module, Response
 
 
@@ -16,7 +16,7 @@ def is_bot_dev(user):
     if user.id == rob_id:
         return True
     roles = getattr(user, "roles", [])
-    return "bot dev" in [role.name for role in roles]
+    return discord.utils.get(roles, id=bot_dev_role_id)
 
 
 class Factoids(Module):

--- a/modules/StampyControls.py
+++ b/modules/StampyControls.py
@@ -1,7 +1,9 @@
 import sys
 import discord
 from modules.module import Module, Response
-from config import stampy_control_channel_names, bot_admin_role_id, TEST_RESPONSE_PREFIX, Services
+from config import TEST_RESPONSE_PREFIX
+from servicemodules.serviceConstants import Services
+from servicemodules.discordConstants import bot_admin_role_id, stampy_control_channel_ids
 from utilities import Utilities, get_github_info, get_memory_usage, get_running_user_info, get_question_id
 
 

--- a/modules/StampyControls.py
+++ b/modules/StampyControls.py
@@ -3,7 +3,7 @@ import discord
 from modules.module import Module, Response
 from config import TEST_RESPONSE_PREFIX
 from servicemodules.serviceConstants import Services
-from servicemodules.discordConstants import bot_admin_role_id, stampy_control_channel_ids
+from servicemodules.discordConstants import bot_admin_role_id, stampy_control_channel_ids, can_invite_role_id, member_role_id
 from utilities import Utilities, get_github_info, get_memory_usage, get_running_user_info, get_question_id
 
 
@@ -83,7 +83,7 @@ class StampyControls(Module):
             discord_guild=guild,
             discord_guild_member_count=len(guild.members),
         )
-        role = discord.utils.get(guild.roles, name="can-invite")
+        role = discord.utils.get(guild.roles, id=can_invite_role_id)
         reset_users_count = 0
         if not self.utils.test_mode:
             for member in guild.members:
@@ -103,7 +103,7 @@ class StampyControls(Module):
         if message.service != Services.DISCORD:
             return Response(confidence=10, text="This feature is only available on Discord")
         guild = message._message.guild
-        member_role = discord.utils.get(guild.roles, name="member")
+        member_role = discord.utils.get(guild.roles, id=member_role_id)
         if not member_role:
             return Response(
                 confidence=10,

--- a/modules/StampyControls.py
+++ b/modules/StampyControls.py
@@ -1,7 +1,7 @@
 import sys
 import discord
 from modules.module import Module, Response
-from config import stampy_control_channel_names, TEST_RESPONSE_PREFIX, Services
+from config import stampy_control_channel_names, bot_admin_role_id, TEST_RESPONSE_PREFIX, Services
 from utilities import Utilities, get_github_info, get_memory_usage, get_running_user_info, get_question_id
 
 
@@ -51,8 +51,8 @@ class StampyControls(Module):
 
     @staticmethod
     async def reboot(message):
-        if hasattr(message.channel, "name") and message.channel.name in stampy_control_channel_names:
-            asked_by_admin = discord.utils.get(message.author.roles, name="bot admin")
+        if hasattr(message.channel, "id") and message.channel.id in stampy_control_channel_ids:
+            asked_by_admin = discord.utils.get(message.author.roles, id=bot_admin_role_id)
             if asked_by_admin:
                 await message.channel.send("Rebooting...")
                 sys.stdout.flush()

--- a/modules/gpt3module.py
+++ b/modules/gpt3module.py
@@ -8,7 +8,7 @@ from config import (
 from modules.module import Module, Response
 from utilities.serviceutils import ServiceMessage
 from servicemodules.serviceConstants import service_italics_marks, default_italics_mark
-from servicemodules.discordConstants import rob_id
+from servicemodules.discordConstants import rob_id, stampy_id
 import openai
 
 openai.api_key = openai_api_key
@@ -129,7 +129,7 @@ class GPT3Module(Module):
         forbidden_tokens = set([])
 
         for message in self.message_logs[channel]:
-            if message.author.name == "stampy":
+            if message.author.id == stampy_id:
                 # we only need the first token, so just clip to ten chars
                 # the space is because we generate from "stampy:" so there's always a space at the start
                 if message.service in service_italics_marks:

--- a/modules/gpt3module.py
+++ b/modules/gpt3module.py
@@ -4,12 +4,11 @@ from config import (
     CONFUSED_RESPONSE,
     openai_api_key,
     goose_api_key,
-    rob_id,
-    service_italics_marks,
-    default_italics_mark,
 )
 from modules.module import Module, Response
 from utilities.serviceutils import ServiceMessage
+from servicemodules.serviceConstants import service_italics_marks, default_italics_mark
+from servicemodules.discordConstants import rob_id
 import openai
 
 openai.api_key = openai_api_key

--- a/modules/invitemanager.py
+++ b/modules/invitemanager.py
@@ -1,6 +1,7 @@
 import re
 import discord
-from config import rob_id, Services
+from servicemodules.discordConstants import rob_id
+from servicemodules.serviceConstants import Services
 from modules.module import Module, Response
 
 

--- a/modules/stampcollection.py
+++ b/modules/stampcollection.py
@@ -37,7 +37,7 @@ class StampsModule(Module):
         self.update_utils()
         self.calculate_stamps()
 
-    def update_vote(self, emoji: str, from_id: Union[int, str], to_id: Union[int, str],
+    def update_vote(self, emoji: str, from_id: int, to_id: int,
                     *, negative: bool = False, recalculate: bool = True):
 
         if (to_id == stampy_id  # votes for stampy do nothing
@@ -149,7 +149,7 @@ class StampsModule(Module):
             stamps_file.readline()  # throw away the first line, it's headers
             for line in stamps_file:
                 msg_id, emoji, from_id, to_id = line.strip().split(",")
-                self.update_vote(emoji, from_id, to_id, recalculate=False)
+                self.update_vote(emoji, int(from_id), int(to_id), recalculate=False)
 
         self.calculate_stamps()
 

--- a/modules/stampcollection.py
+++ b/modules/stampcollection.py
@@ -4,8 +4,9 @@ import discord
 import numpy as np
 from utilities import utilities
 from modules.module import Module, Response
-from config import stampy_id
-from config import stamp_scores_csv_file_path, Services
+from config import stamp_scores_csv_file_path
+from servicemodules.serviceConstants import Services
+from servicemodules.discordConstants import stampy_id
 from utilities.discordutils import DiscordMessage
 
 

--- a/modules/stampcollection.py
+++ b/modules/stampcollection.py
@@ -6,7 +6,7 @@ from utilities import utilities
 from modules.module import Module, Response
 from config import stamp_scores_csv_file_path
 from servicemodules.serviceConstants import Services
-from servicemodules.discordConstants import stampy_id
+from servicemodules.discordConstants import stampy_id, bot_admin_role_id
 from utilities.discordutils import DiscordMessage
 
 
@@ -270,7 +270,7 @@ class StampsModule(Module):
 
             elif text == "reloadallstamps":
                 if message.service == Services.DISCORD:
-                    asked_by_admin = discord.utils.get(message.author.roles, name="bot admin")
+                    asked_by_admin = discord.utils.get(message.author.roles, id=bot_admin_role_id)
                     if asked_by_admin:
                         return Response(confidence=10, callback=self.reloadallstamps, args=[message])
                 else:

--- a/modules/testModule.py
+++ b/modules/testModule.py
@@ -3,7 +3,8 @@ from asyncio import sleep
 from utilities import get_question_id, is_test_response
 from modules.module import Module, Response
 from jellyfish import jaro_winkler_similarity
-from config import TEST_QUESTION_PREFIX, TEST_RESPONSE_PREFIX, test_response_message, Services
+from config import TEST_QUESTION_PREFIX, TEST_RESPONSE_PREFIX, test_response_message
+from servicemodules.serviceConstants import Services
 
 
 class TestModule(Module):

--- a/scripts/notify-discord-stampy-offline.py
+++ b/scripts/notify-discord-stampy-offline.py
@@ -1,7 +1,7 @@
 import discord
 from git import Repo, cmd
 from structlog import get_logger
-from config import bot_dev_channel_id, discord_token
+from config import stampy_dev_priv_channel_id, discord_token
 
 client = discord.Client()
 log = get_logger()
@@ -24,7 +24,7 @@ async def on_ready():
     date = master.commit.committed_datetime.strftime("%A, %B %d, %Y at %I:%M:%S %p UTC%z")
     message = offline_message % (actor, git_message, date)
     log.info("notify_discord_script", msg=message)
-    await client.get_channel(bot_dev_channel_id).send(message)
+    await client.get_channel(stampy_dev_priv_channel_id).send(message)
     log.info("notify_discord_script", status="COMPLETE")
     exit()
 

--- a/servicemodules/discord.py
+++ b/servicemodules/discord.py
@@ -24,7 +24,7 @@ from config import (
     TEST_RESPONSE_PREFIX,
     maximum_recursion_depth,
 )
-from servicemodules.discordConstants import stampy_dev_priv_channel_id
+from servicemodules.discordConstants import stampy_dev_priv_channel_id, automatic_question_channel_id
 
 log = get_logger()
 class_name = "DiscordHandler"
@@ -92,7 +92,7 @@ class DiscordHandler:
                 message_content=message.content,
             )
 
-            if hasattr(message.channel, "name") and message.channel.name == "general":
+            if hasattr(message.channel, "id") and message.channel.id == automatic_question_channel_id:
                 log.info(class_name, msg="the latest general discord channel message was not from stampy")
                 self.utils.last_message_was_youtube_question = False
 
@@ -232,7 +232,7 @@ class DiscordHandler:
                         guild = discord.utils.find(
                             lambda g: g.name == self.utils.GUILD, self.utils.client.guilds
                         )
-                        general = discord.utils.find(lambda c: c.name == "general", guild.channels)
+                        general = discord.utils.get(guild.channels, id=automatic_question_channel_id)
                         await general.send(report)
                         self.utils.last_message_was_youtube_question = True
                     else:

--- a/servicemodules/discord.py
+++ b/servicemodules/discord.py
@@ -21,10 +21,10 @@ from datetime import datetime, timezone, timedelta
 from typing import Generator
 from config import (
     discord_token,
-    bot_dev_channel_id,
     TEST_RESPONSE_PREFIX,
     maximum_recursion_depth,
 )
+from servicemodules.discordConstants import stampy_dev_priv_channel_id
 
 log = get_logger()
 class_name = "DiscordHandler"
@@ -56,7 +56,7 @@ class DiscordHandler:
 
             members = "\n - " + "\n - ".join([member.name for member in guild.members])
             log.info(class_name, guild_members=members)
-            await self.utils.client.get_channel(bot_dev_channel_id).send(
+            await self.utils.client.get_channel(stampy_dev_priv_channel_id).send(
                 f"I just (re)started {get_git_branch_info()}!"
             )
 

--- a/servicemodules/discordConstants.py
+++ b/servicemodules/discordConstants.py
@@ -63,4 +63,4 @@ member_role_id: int = {"production": 945033781818040391, "development": 94746361
 # pretty sure can-invite is deprecated, but putting it here for completeness
 
 rob_id: int = 181142785259208704
-stampy_id: int = "736241264856662038"
+stampy_id: int = 736241264856662038

--- a/servicemodules/discordConstants.py
+++ b/servicemodules/discordConstants.py
@@ -1,0 +1,58 @@
+from config import ENVIRONMENT_TYPE
+
+#################################
+# RAW DATA FOR ALL CHANNEL IDS
+#################################
+welcome_channel_id: int = {"production": 743842679741481051, "development": 817518666349412352}[ENVIRONMENT_TYPE]
+introductions_channel_id: int = {"production": 741764243753402389, "development": 817518698339500053}[ENVIRONMENT_TYPE]
+
+core_category_id: int = {"production": 1036026077576962198, "development": -2}[ENVIRONMENT_TYPE]
+general_channel_id: int = {"production": 677546901339504646, "development": 783123903382814723}[ENVIRONMENT_TYPE]
+ai_safety_questions_channel_id: int = {"production": 1036026287459934298, "development": -2}[ENVIRONMENT_TYPE]
+aligned_intelligences_only_channel_id: int = {"production": 948354810002944070, "development": -2}[ENVIRONMENT_TYPE]
+voice_channel_id: int = {"production": 677546901339504648, "development": 783123903382814724}[ENVIRONMENT_TYPE]
+
+stampy_category_id: int = {"production": 812043478321987635, "development": -2}[ENVIRONMENT_TYPE]
+stampy_dev_channel_id: int = {"production": 758062805810282526, "development": 817518145472299009}[ENVIRONMENT_TYPE]
+wiki_channel_id: int = {"production": 835222827207753748, "development": 871715944114819092}[ENVIRONMENT_TYPE]
+talk_to_stampy_channel_id: int = {"production": 808138366330994688, "development": 817518440192409621}[ENVIRONMENT_TYPE]
+wiki_feed_channel_id: int = {"production": 819348467876364288, "development": 818635466478846033}[ENVIRONMENT_TYPE]
+stampy_dev_priv_channel_id: int = {"production": 736247813616304159, "development": 817518389848309760}[ENVIRONMENT_TYPE]
+stampy_error_log_channel_id: int = {"production": 1017527224540344380, "development": 1017531179664150608}[ENVIRONMENT_TYPE]
+off_topic_channel_id: int = {"production": 997857170647433257, "development": -2}[ENVIRONMENT_TYPE]
+memes_channel_id: int = {"production": 843628797270294568, "development": -2}[ENVIRONMENT_TYPE]
+
+other_channels_category_id: int = {"production": 677546901339504642, "development": 783123903382814721}[ENVIRONMENT_TYPE]
+ai_channel_id: int = {"production": 817511894671294524, "development": 817517982832918558}[ENVIRONMENT_TYPE]
+not_ai_channel_id: int = {"production": 757908690165694546, "development": 817518001237655552}[ENVIRONMENT_TYPE]
+events_channel_id: int = {"production": 789918737415012384, "development": 817518818951430184}[ENVIRONMENT_TYPE]
+projects_channel_id: int = {"production": 787117276960522280, "development": 817518806472589342}[ENVIRONMENT_TYPE]
+book_club_channel_id: int = {"production": 929823603766222919, "development": -2}[ENVIRONMENT_TYPE]
+dialogues_with_stampy_channel_id: int = {"production": 1013976966564675644, "development": -2}[ENVIRONMENT_TYPE]
+meta_channel_id: int = {"production": 741332060031156296, "development": 817518780509847562}[ENVIRONMENT_TYPE]
+
+archive_category_id: int = {"production": 929823542818766948, "development": -2}[ENVIRONMENT_TYPE]
+voice_context_channel_id: int = {"production": 810261871029387275, "development": -2}[ENVIRONMENT_TYPE]
+editing_channel_id: int = {"production": 990947616252657667, "development": -2}[ENVIRONMENT_TYPE]
+
+test_channel_id: int = {"production": -99, "development": 803448149946662923}[ENVIRONMENT_TYPE]
+bot_owner_dms_id: int = {"production": -1, "development": 736241264856662038}[ENVIRONMENT_TYPE] #TODO: replace -1 with the id for robs DM with stampy,
+
+# TODO: it would be good if we had a test that warned us if the above did not actually match up with the server layout
+
+#################################
+# ID DERIVED VARIABLES
+#################################
+
+stampy_control_channel_ids = (test_channel_id, stampy_dev_priv_channel_id, stampy_dev_channel_id,
+                              talk_to_stampy_channel_id, bot_owner_dms_id)
+
+
+#################################
+# USER/ROLE IDs (not complete due to lack of need)
+#################################
+
+bot_admin_role_id: int = {"production": 819898114823159819, "development": 948709263461711923}[ENVIRONMENT_TYPE]
+
+rob_id = 181142785259208704
+stampy_id = "736241264856662038"

--- a/servicemodules/discordConstants.py
+++ b/servicemodules/discordConstants.py
@@ -1,8 +1,10 @@
 from config import ENVIRONMENT_TYPE
+from typing import Tuple
 
 #################################
 # RAW DATA FOR ALL CHANNEL IDS
 #################################
+
 welcome_channel_id: int = {"production": 743842679741481051, "development": 817518666349412352}[ENVIRONMENT_TYPE]
 introductions_channel_id: int = {"production": 741764243753402389, "development": 817518698339500053}[ENVIRONMENT_TYPE]
 
@@ -44,8 +46,10 @@ bot_owner_dms_id: int = {"production": -1, "development": 736241264856662038}[EN
 # ID DERIVED VARIABLES
 #################################
 
-stampy_control_channel_ids = (test_channel_id, stampy_dev_priv_channel_id, stampy_dev_channel_id,
-                              talk_to_stampy_channel_id, bot_owner_dms_id)
+automatic_question_channel_id = general_channel_id  # TODO: should this be ai_safety_questions_channel_id?
+
+stampy_control_channel_ids: Tuple[int, ...] = (test_channel_id, stampy_dev_priv_channel_id, stampy_dev_channel_id,
+                                               talk_to_stampy_channel_id, bot_owner_dms_id)
 
 
 #################################
@@ -53,6 +57,10 @@ stampy_control_channel_ids = (test_channel_id, stampy_dev_priv_channel_id, stamp
 #################################
 
 bot_admin_role_id: int = {"production": 819898114823159819, "development": 948709263461711923}[ENVIRONMENT_TYPE]
+bot_dev_role_id: int = {"production": 736247946676535438, "development": 817518998148087858}[ENVIRONMENT_TYPE]
+can_invite_role_id: int = {"production": 791424708973035540, "development": -99}[ENVIRONMENT_TYPE]
+member_role_id: int = {"production": 945033781818040391, "development": 947463614841901117}[ENVIRONMENT_TYPE]
+# pretty sure can-invite is deprecated, but putting it here for completeness
 
-rob_id = 181142785259208704
-stampy_id = "736241264856662038"
+rob_id: int = 181142785259208704
+stampy_id: int = "736241264856662038"

--- a/servicemodules/serviceConstants.py
+++ b/servicemodules/serviceConstants.py
@@ -1,0 +1,46 @@
+from enum import Enum
+from servicemodules import discordConstants
+
+
+class Services(Enum):
+    DISCORD = "Discord"
+    FLASK = "Flask"
+    SLACK = "Slack"
+
+    def __str__(self) -> None:
+        return str(self._value_)
+
+    def __eq__(self, other: object) -> bool:
+        try:
+            return str(self) == str(other)
+        except Exception:
+            return False
+
+    def __hash__(self):
+
+        return hash(str(self)) >> 22
+
+
+openai_channel_ids: dict[Services, tuple[int, ...]] = {
+    Services.DISCORD: (
+        discordConstants.stampy_dev_priv_channel_id,
+        discordConstants.aligned_intelligences_only_channel_id,
+        discordConstants.ai_channel_id,
+        discordConstants.not_ai_channel_id,
+        discordConstants.events_channel_id,
+        discordConstants.projects_channel_id,
+        discordConstants.book_club_channel_id,
+        discordConstants.dialogues_with_stampy_channel_id,
+        discordConstants.meta_channel_id,
+
+    )
+}
+
+
+service_italics_marks = {
+    Services.SLACK: "_",
+    Services.FLASK: "",
+}
+
+
+default_italics_mark = "*"

--- a/stam.py
+++ b/stam.py
@@ -12,8 +12,8 @@ from config import (
     prod_local_path,
     ENVIRONMENT_TYPE,
     acceptable_environment_types,
-    Services,
 )
+from servicemodules.serviceConstants import Services
 
 log_type = "stam.py"
 log = get_logger()

--- a/test/modules/test_Eliza.py
+++ b/test/modules/test_Eliza.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
-from utilities.serviceutils import ServiceMessage, ServiceUser, Services
+from servicemodules.serviceConstants import Services
+from utilities.serviceutils import ServiceMessage, ServiceUser
 from utilities import Utilities
 from servicemodules.discord import DiscordHandler
 from modules.Eliza import Eliza

--- a/utilities/discordutils.py
+++ b/utilities/discordutils.py
@@ -1,8 +1,8 @@
+from servicemodules.serviceConstants import Services
 from utilities.serviceutils import (
     ServiceChannel,
     ServiceMessage,
     ServiceRole,
-    Services,
     ServiceServer,
     ServiceUser,
 )

--- a/utilities/flaskutils.py
+++ b/utilities/flaskutils.py
@@ -1,4 +1,5 @@
-from utilities.serviceutils import ServiceUser, ServiceServer, ServiceChannel, ServiceMessage, Services
+from servicemodules.serviceConstants import Services
+from utilities.serviceutils import ServiceUser, ServiceServer, ServiceChannel, ServiceMessage
 import threading
 import time
 

--- a/utilities/serviceutils.py
+++ b/utilities/serviceutils.py
@@ -1,4 +1,4 @@
-from config import Services
+from servicemodules.serviceConstants import Services
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Optional

--- a/utilities/slackutils.py
+++ b/utilities/slackutils.py
@@ -1,5 +1,6 @@
 from functools import cache
-from utilities.serviceutils import ServiceUser, ServiceServer, ServiceChannel, ServiceMessage, Services
+from servicemodules.serviceConstants import Services
+from utilities.serviceutils import ServiceUser, ServiceServer, ServiceChannel, ServiceMessage
 from typing import Any
 
 

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -5,14 +5,13 @@ from config import (
     rob_miles_youtube_channel_id,
     discord_token,
     discord_guild,
-    error_channel_id,
     youtube_api_key,
     database_path,
     TEST_RESPONSE_PREFIX,
     TEST_QUESTION_PREFIX,
     wiki_config,
-    wikifeed_id,
 )
+from servicemodules.discordConstants import stampy_error_log_channel_id, wiki_feed_channel_id
 from database.database import Database
 from datetime import datetime, timezone, timedelta
 from enum import Enum
@@ -170,7 +169,7 @@ class Utilities:
         return self.is_stampy(message.author)
 
     def is_stampy(self, user: DiscordUser) -> bool:
-        if user.id == wikifeed_id:  # consider wiki-feed ID as stampy to ignore -- is it better to set a wiki user?
+        if user.id == wiki_feed_channel_id:  # consider wiki-feed ID as stampy to ignore -- is it better to set a wiki user?
             return True
         if self.discord_user:
             return user == self.discord_user
@@ -556,7 +555,7 @@ class Utilities:
 
     async def log_error(self, error_message: str) -> None:
         if self.error_channel is None:
-            self.error_channel = self.client.get_channel(error_channel_id)
+            self.error_channel = self.client.get_channel(stampy_error_log_channel_id)
         for msg_chunk in Utilities.split_message_for_discord(error_message, max_length=discord_message_length_limit-6):
             await self.error_channel.send(f"```{msg_chunk}```")
 


### PR DESCRIPTION
Changed all references to discord channel names to reference ID instead so that we can rename them without worry.

Also split up config into multiple specialized files since it was getting very cramped

servicemodules/serviceConstants.py is there in preparation for a future where openai_channel_ids has ids for slack and flask, as seems to have been intended by whoever created the variable. But it may end up being the case that we want to merge that file with service utils or with discordConstants.