### PR TITLE
finally sorted out all the places ids need to be ints from where they need to be strings

### DIFF
--- a/modules/StampyControls.py
+++ b/modules/StampyControls.py
@@ -88,7 +88,7 @@ class StampyControls(Module):
             discord_guild=guild,
             discord_guild_member_count=len(guild.members),
         )
-        role = discord.utils.get(guild.roles, id=can_invite_role_id)
+        role = discord.utils.get(guild.roles, id=int(can_invite_role_id))
         reset_users_count = 0
         if not self.utils.test_mode:
             for member in guild.members:
@@ -108,7 +108,7 @@ class StampyControls(Module):
         if message.service != Services.DISCORD:
             return Response(confidence=10, text="This feature is only available on Discord")
         guild = message._message.guild
-        member_role = discord.utils.get(guild.roles, id=member_role_id)
+        member_role = discord.utils.get(guild.roles, id=int(member_role_id))
         if not member_role:
             return Response(
                 confidence=10,

--- a/modules/stampcollection.py
+++ b/modules/stampcollection.py
@@ -220,10 +220,11 @@ class StampsModule(Module):
         message = DiscordMessage(await channel.fetch_message(event.message_id))
         emoji = getattr(event.emoji, "name", event.emoji)
 
+        author_id_int = int(message.author.id)
         if utilities.stampy_is_author(message):
             # votes for stampy don't affect voting
             return
-        if message.author.id == event.user_id:
+        if author_id_int == event.user_id:
             # votes for yourself don't affect voting
             # if event_type == 'REACTION_ADD' and emoji in ['stamp', 'goldstamp']:
             # 	await channel.send("<@" + str(event.user_id) + "> just awarded a stamp to themselves...")
@@ -233,7 +234,7 @@ class StampsModule(Module):
 
             ms_gid = event.message_id
             from_id = event.user_id
-            to_id = message.author.id
+            to_id = author_id_int
             
             self.log.info(
                 self.class_name,

--- a/scripts/notify-discord-stampy-offline.py
+++ b/scripts/notify-discord-stampy-offline.py
@@ -24,7 +24,7 @@ async def on_ready():
     date = master.commit.committed_datetime.strftime("%A, %B %d, %Y at %I:%M:%S %p UTC%z")
     message = offline_message % (actor, git_message, date)
     log.info("notify_discord_script", msg=message)
-    await client.get_channel(stampy_dev_priv_channel_id).send(message)
+    await client.get_channel(int(stampy_dev_priv_channel_id)).send(message)
     log.info("notify_discord_script", status="COMPLETE")
     exit()
 

--- a/servicemodules/discord.py
+++ b/servicemodules/discord.py
@@ -56,7 +56,7 @@ class DiscordHandler:
 
             members = "\n - " + "\n - ".join([member.name for member in guild.members])
             log.info(class_name, guild_members=members)
-            await self.utils.client.get_channel(stampy_dev_priv_channel_id).send(
+            await self.utils.client.get_channel(int(stampy_dev_priv_channel_id)).send(
                 f"I just (re)started {get_git_branch_info()}!"
             )
 
@@ -92,7 +92,7 @@ class DiscordHandler:
                 message_content=message.content,
             )
 
-            if hasattr(message.channel, "id") and message.channel.id == automatic_question_channel_id:
+            if hasattr(message.channel, "id") and str(message.channel.id) == automatic_question_channel_id:
                 log.info(class_name, msg="the latest general discord channel message was not from stampy")
                 self.utils.last_message_was_youtube_question = False
 
@@ -232,7 +232,7 @@ class DiscordHandler:
                         guild = discord.utils.find(
                             lambda g: g.name == self.utils.GUILD, self.utils.client.guilds
                         )
-                        general = discord.utils.get(guild.channels, id=automatic_question_channel_id)
+                        general = discord.utils.get(guild.channels, id=int(automatic_question_channel_id))
                         await general.send(report)
                         self.utils.last_message_was_youtube_question = True
                     else:

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -555,7 +555,7 @@ class Utilities:
 
     async def log_error(self, error_message: str) -> None:
         if self.error_channel is None:
-            self.error_channel = self.client.get_channel(stampy_error_log_channel_id)
+            self.error_channel = self.client.get_channel(int(stampy_error_log_channel_id))
         for msg_chunk in Utilities.split_message_for_discord(error_message, max_length=discord_message_length_limit-6):
             await self.error_channel.send(f"```{msg_chunk}```")
 


### PR DESCRIPTION
Much confusion was caused by the fact that it is not consistent which places need each. The current solution is to store ids as strings by default, because slack has alphanumeric ids, and convert to int only where needed.