### PR TITLE
Fixing stampy providing the next question when not even remotely asked for it.

### DIFF
--- a/modules/questions.py
+++ b/modules/questions.py
@@ -416,7 +416,7 @@ _PAT_NEXT_QUESTION = r"""
     |
         ([Hh]ave\syou\s)?
         [gG]ot
-    )?
+    )
     (
         \s?[Aa]ny(\smore|\sother)?
     |


### PR DESCRIPTION
Previous Matches:
```
SUCCESS: ("Can you give us another question?"))
SUCCESS: ("Do you have any more questions for us?"))
SUCCESS: ("next 5 questions"))
SUCCESS: ('give us next 2 questions with status live on site and tagged as "decision theory"'))
FALSE POSITIVE: ("how many stamps can i buy"))
FALSE POSITIVE: ("Stampy how many stamps is 1 dollar worth"))
FALSE POSITIVE: ("Stampy how many stamps is 200 dollars worth"))
FALSE POSITIVE: ("any stamps?"))
FALSE POSITIVE: ('Stampy, can you direct me to any info about "giant inscrutable matrices"?'))
```
Now:
```
SUCCESS: ("Can you give us another question?"))
SUCCESS: ("Do you have any more questions for us?"))
SUCCESS: ("next 5 questions"))
SUCCESS: ('give us next 2 questions with status live on site and tagged as "decision theory"'))
NO MATCH: ("how many stamps can i buy"))
NO MATCH: ("Stampy how many stamps is 1 dollar worth"))
NO MATCH: ("Stampy how many stamps is 200 dollars worth"))
NO MATCH: ("any stamps?"))
NO MATCH: ('Stampy, can you direct me to any info about "giant inscrutable matrices"?'))
```