### PR TITLE
Proposal: `-Werror` in dev

### DIFF
--- a/stam.py
+++ b/stam.py
@@ -1,10 +1,25 @@
 import os
+from sys import warnoptions
+
+from config import database_path, enabled_modules, ALL_STAMPY_MODULES, ENVIRONMENT_TYPE
+
+if not warnoptions: # if user hasn't passed explicit warning settings
+    import warnings
+    if ENVIRONMENT_TYPE == "development":
+        warnlevel = 'error'
+    elif ENVIRONMENT_TYPE == "production":
+        warnlevel = 'always'
+    else:
+        raise Exception(f"Unknown environment type {ENVIRONMENT_TYPE}")
+
+    warnings.simplefilter(warnlevel) # Change the filter in this process
+    os.environ["PYTHONWARNINGS"] = warnlevel # Also affect subprocesses
+
 import threading
 from typing import cast
 
 from structlog import get_logger
 
-from config import database_path, enabled_modules, ALL_STAMPY_MODULES
 from modules.module import Module
 from servicemodules.discord import DiscordHandler
 from servicemodules.flask import FlaskHandler

--- a/stam.py
+++ b/stam.py
@@ -6,16 +6,16 @@ from config import database_path, enabled_modules, ALL_STAMPY_MODULES, ENVIRONME
 if not warnoptions: # if user hasn't passed explicit warning settings
     import warnings
     from typing import Literal
-    warnlevel: Literal['default', 'error', 'ignore', 'always', 'module', 'once']
+    WARN_LEVEL: Literal['default', 'error', 'ignore', 'always', 'module', 'once']
     if ENVIRONMENT_TYPE == "development":
-        warnlevel = 'error'
+        WARN_LEVEL = 'error'
     elif ENVIRONMENT_TYPE == "production":
-        warnlevel = 'always'
+        WARN_LEVEL = 'always'
     else:
         raise Exception(f"Unknown environment type {ENVIRONMENT_TYPE}")
 
-    warnings.simplefilter(warnlevel) # Change the filter in this process
-    os.environ["PYTHONWARNINGS"] = warnlevel # Also affect subprocesses
+    warnings.simplefilter(WARN_LEVEL) # Change the filter in this process
+    os.environ["PYTHONWARNINGS"] = WARN_LEVEL # Also affect subprocesses
 
 import threading
 from typing import cast

--- a/stam.py
+++ b/stam.py
@@ -5,6 +5,8 @@ from config import database_path, enabled_modules, ALL_STAMPY_MODULES, ENVIRONME
 
 if not warnoptions: # if user hasn't passed explicit warning settings
     import warnings
+    from typing import Literal
+    warnlevel: Literal['default', 'error', 'ignore', 'always', 'module', 'once']
     if ENVIRONMENT_TYPE == "development":
         warnlevel = 'error'
     elif ENVIRONMENT_TYPE == "production":


### PR DESCRIPTION
Treats warnings as exceptions when in development, else always display them. This would have caught a text formatting bug that was lingering around, silently failing otherwise.

I prefer developing this way but you don't have to, feel free to reject :) Can someone verify this works with fancier modules which I don't have keys to, I.e. Coda, Wolfram, ChatGPT, etc?