### PR TITLE
Keep certain jokes from repeating

### DIFF
--- a/modules/Random.py
+++ b/modules/Random.py
@@ -57,36 +57,5 @@ class Random(Module):
                 why="%s asked me to choose between the options [%s]" % (who, ", ".join(options)),
             )
 
-        elif (atme or randbool(0.5)) and " or " in text and len(text.split()) < 20:
-            # repetition guard
-            if atme and utils.messageRepeated(message, text):
-                self.log.info(
-                    self.class_name, msg="We don't want to lock people in due to phrasing"
-                )
-                return Response()
-
-            options = [option.strip() for option in re.split(" or |,", text.strip("?")) if option.strip()]
-            try:  # reflect with ELIZA if available
-                result = self.utils.modules_dict["Eliza"].reflect(random.choice(options))
-                replacements = [
-                    ("were it", "it was"),
-                    ("are it", "it is"),
-                    ("will it", "it will"),
-                    ("am me", "I am"),
-                    ("will me", "I will"),
-                    ("are you", "you are"),
-                    ("will you", "you will"),
-                    ("should you", "you should"),
-                ]
-                for old, new in replacements:
-                    result = result.replace(old, new)
-            except:
-                result = random.choice(options)
-            return Response(
-                confidence=6,
-                text=random.choice(options),
-                why="%s implied a choice between the options [%s]" % (who, ", ".join(options)),
-            )
-
     def __str__(self):
         return "Random"

--- a/modules/Random.py
+++ b/modules/Random.py
@@ -2,7 +2,9 @@ import re
 import random
 from modules.module import Module, Response
 
-from utilities.utilities import randbool
+from utilities.utilities import Utilities, randbool
+
+utils = Utilities.get_instance()
 
 class Random(Module):
     def process_message(self, message):
@@ -40,6 +42,12 @@ class Random(Module):
 
         # "Stampy, choose coke or pepsi or both"
         elif text.startswith("choose ") and " or " in text:
+            # repetition guard
+            if atme and utils.messageRepeated(message, text):
+                self.log.info(
+                    self.class_name, msg="We don't want to lock people in due to phrasing"
+                )
+                return Response()
             cstring = text.partition(" ")[2].strip("?")
             # options = [option.strip() for option in cstring.split(" or ")]  # No oxford commas please
             options = [option.strip() for option in re.split(" or |,", cstring) if option.strip()]
@@ -50,6 +58,13 @@ class Random(Module):
             )
 
         elif (atme or randbool(0.5)) and " or " in text and len(text.split()) < 20:
+            # repetition guard
+            if atme and utils.messageRepeated(message, text):
+                self.log.info(
+                    self.class_name, msg="We don't want to lock people in due to phrasing"
+                )
+                return Response()
+
             options = [option.strip() for option in re.split(" or |,", text.strip("?")) if option.strip()]
             try:  # reflect with ELIZA if available
                 result = self.utils.modules_dict["Eliza"].reflect(random.choice(options))

--- a/modules/Silly.py
+++ b/modules/Silly.py
@@ -248,5 +248,30 @@ class Silly(Module):
         else:
             return Response()
 
+        # if the sentence looks like it might be a choice, choose between them sometimes
+        if (atme or randbool(0.5)) and " or " in text and len(text.split()) < 20:
+            options = [option.strip() for option in re.split(" or |,", text.strip("?")) if option.strip()]
+            try:  # reflect with ELIZA if available
+                result = self.utils.modules_dict["Eliza"].reflect(random.choice(options))
+                replacements = [
+                    ("were it", "it was"),
+                    ("are it", "it is"),
+                    ("will it", "it will"),
+                    ("am me", "I am"),
+                    ("will me", "I will"),
+                    ("are you", "you are"),
+                    ("will you", "you will"),
+                    ("should you", "you should"),
+                ]
+                for old, new in replacements:
+                    result = result.replace(old, new)
+            except:
+                result = random.choice(options)
+            return Response(
+                confidence=6,
+                text=r"I choose {random.choice(options)}",
+                why="%s implied a choice between the options [%s]" % (who, ", ".join(options)),
+            )
+
     def __str__(self):
         return "Silly"

--- a/modules/Silly.py
+++ b/modules/Silly.py
@@ -4,18 +4,29 @@ import urllib
 import datetime
 import string
 
-from modules.module import Module, Response
-from utilities.utilities import randbool
+from typing import Dict
+from modules.module import Module, Response, ServiceMessage
+from utilities.utilities import Utilities, randbool
 
+utils = Utilities.get_instance()
 
 class Silly(Module):
+    def __init__(self):
+        super().__init__()
+
     def process_message(self, message):
         atme = self.is_at_me(message)
         text = atme or message.clean_content
         who = message.author.name
         print(atme)
         print(text)
-        
+
+        if atme and utils.messageRepeated(message, text):
+            self.log.info(
+                self.class_name, msg="We don't want to lock people in due to phrasing"
+            )
+            return Response()
+
         if text.lower() == "show me how exceptional you are!":
             class SillyError(Exception):
                 pass

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -100,6 +100,9 @@ class Utilities:
             discord.Thread, self.client.get_channel(int(stampy_error_log_channel_id))
         )
 
+        # Last messages we got per channel, for annoyance prevention
+        self.lastMessages: Dict[int, str] = {}
+
         self.users: list[int] = []
         self.ids: list[int] = []
         self.index: dict[int, int] = {}
@@ -295,6 +298,31 @@ class Utilities:
                 next_split_marker = split_marker_try + 1
         output.append(msg[last_split_index:])
         return output
+
+    def messageRepeated(self, message: ServiceMessage, this_text: str) -> bool:
+        """
+        This function keeps a log of the last messages by channel and returns
+        true if this text is identical to the last text. To use, find the block
+        where a response is chosen and add a guard at the top
+
+        ```
+        # repetition guard
+        if self.is_at_me(message) and Utilities.get_instance().messageRepeated(message, text):
+            self.log.info(
+                self.class_name, msg="We don't want to lock people in due to phrasing"
+            )
+            return Response()
+        ```
+        """
+        chan = message.channel.id
+        if not chan in self.lastMessages:
+            self.lastMessages[chan] = this_text
+            return False
+        elif self.lastMessages[chan] == this_text:
+            return True
+        else:
+            self.lastMessages[chan] = this_text
+            return False
 
 
 def get_github_info() -> str:


### PR DESCRIPTION
If I need some specific answer from Stampy, I've regularly run into jokes that interrupt my interaction. This wouldn't be a problem if the jokes didn't trigger for every message meeting certain criteria. For example, a message at Stampy with the word "or" *always* triggers the random choice functionality from Silly.py and Random.py. This introduces a function to check if this message is repeated, and if it is, return False. You can then use this function to wrap some troublesome joke, such that if your request is caught by it, just sending the exact same request a second time will disable it. Maybe there's more ways to expand it. Thoughts?