### PR TITLE
Shorter tracebacks (bad solution maybe?)

### DIFF
--- a/modules/AlignmentNewsletterSearch.py
+++ b/modules/AlignmentNewsletterSearch.py
@@ -147,7 +147,7 @@ class AlignmentNewsletterSearch(Module):
 
         query = match.group("query")
         return Response(
-            confidence=9, callback=self.process_search_request, kwargs={"self": self, "prompt": query}
+            confidence=9, callback=self.process_search_request, kwargs={"prompt": query}
         )
 
     async def process_search_request(self, prompt: str) -> Response:

--- a/modules/AlignmentNewsletterSearch.py
+++ b/modules/AlignmentNewsletterSearch.py
@@ -147,16 +147,17 @@ class AlignmentNewsletterSearch(Module):
 
         query = match.group("query")
         return Response(
-            confidence=9, callback=self.process_search_request, args=[query]
+            confidence=9, callback=self.process_search_request, kwargs={"self": self, "prompt": query}
         )
 
-    async def process_search_request(self, query) -> Response:
+    async def process_search_request(self, prompt: str) -> Response:
         """Search for relevant items for the query.
 
         First we load all items from the Alignment Newsletter database.
         Then we sort the items by relevance to the query.
         Finally we return the most relevant items, if any.
         """
+        query = prompt
         self.log.info(self.class_name, newsletter_query=query)
 
         items = self.load_items()

--- a/modules/Eliza.py
+++ b/modules/Eliza.py
@@ -46,6 +46,6 @@ class Eliza(Module):
                 return Response(
                     confidence=1,
                     text=result,
-                    why=f"{message.author.name} said '{text}', and ELIZA responded '{result}'" ,
+                    why=f"It seemed like a good idea at the time" ,
                 )
         return Response()

--- a/modules/Silly.py
+++ b/modules/Silly.py
@@ -19,8 +19,8 @@ class Silly(Module):
         atme = self.is_at_me(message)
         text = atme or message.clean_content
         who = message.author.name
-        print(atme)
-        print(text)
+        #print(atme) # DEBUG
+        #print(text) # DEBUG
 
         if atme and utils.message_repeated(message, text):
             self.log.info(

--- a/modules/chatgpt.py
+++ b/modules/chatgpt.py
@@ -67,7 +67,7 @@ class ChatGPTModule(Module):
             return Response()
 
         return Response(
-            confidence=3, callback=self.chatgpt_chat, kwargs={"self": self, "prompt": message }
+            confidence=3, callback=self.chatgpt_chat, kwargs={ "prompt": message }
         )
 
     def process_message_from_stampy(self, message) -> None:

--- a/modules/chatgpt.py
+++ b/modules/chatgpt.py
@@ -67,7 +67,7 @@ class ChatGPTModule(Module):
             return Response()
 
         return Response(
-            confidence=3, callback=self.chatgpt_chat, args=[message], kwargs={}
+            confidence=3, callback=self.chatgpt_chat, kwargs={"self": self, "prompt": message }
         )
 
     def process_message_from_stampy(self, message) -> None:
@@ -116,8 +116,9 @@ class ChatGPTModule(Module):
 
         return messages
 
-    async def chatgpt_chat(self, message: ServiceMessage) -> Response:
+    async def chatgpt_chat(self, prompt: ServiceMessage) -> Response:
         """Ask ChatGPT what Stampy would say next in the chat log"""
+        message: ServiceMessage = prompt
         if self.openai is None:
             return Response()
 

--- a/modules/duckduckgo.py
+++ b/modules/duckduckgo.py
@@ -23,7 +23,7 @@ class DuckDuckGo(Module):
                 return Response(
                     confidence=10,
                     callback=self.ask,
-                    kwargs={ "self": self, "prompt": text[m.end(0):] },
+                    kwargs={ "prompt": text[m.end(0):] },
                     why="This is definitely a web search",
                 )
             print(f"Text didn't match: {text}")
@@ -31,13 +31,13 @@ class DuckDuckGo(Module):
                 return Response(
                     confidence=6,
                     callback=self.ask,
-                    kwargs={ "self": self, "prompt": text },
+                    kwargs={ "prompt": text },
                     why="It's a question, we might be able to answer it",
                 )
             return Response(
                 confidence=2,
                 callback=self.ask,
-                kwargs={ "self": self, "prompt": text },
+                kwargs={ "prompt": text },
                 why="It's not a question but we might be able to look it up",
             )
         return Response()

--- a/modules/duckduckgo.py
+++ b/modules/duckduckgo.py
@@ -23,7 +23,7 @@ class DuckDuckGo(Module):
                 return Response(
                     confidence=10,
                     callback=self.ask,
-                    args=[text[m.end(0):]],
+                    kwargs={ "self": self, "prompt": text[m.end(0):] },
                     why="This is definitely a web search",
                 )
             print(f"Text didn't match: {text}")
@@ -31,13 +31,13 @@ class DuckDuckGo(Module):
                 return Response(
                     confidence=6,
                     callback=self.ask,
-                    args=[text],
+                    kwargs={ "self": self, "prompt": text },
                     why="It's a question, we might be able to answer it",
                 )
             return Response(
                 confidence=2,
                 callback=self.ask,
-                args=[text],
+                kwargs={ "self": self, "prompt": text },
                 why="It's not a question but we might be able to look it up",
             )
         return Response()
@@ -57,12 +57,12 @@ class DuckDuckGo(Module):
             return 1
         return max_confidence
 
-    def ask(self, question: str) -> Response:
+    def ask(self, prompt: str) -> Response:
         """Ask DuckDuckGo a question and return a response."""
 
         # strip out question mark and common 'question phrases', e.g. 'who are',
         # 'what is', 'tell me about'
-        q = question.lower().strip().strip("?")
+        q = prompt.lower().strip().strip("?")
         q = re.sub(r"w(hat|ho)('s|'re| is| are| was| were) ?", "", q)
         q = re.sub(r"(what do you know|(what )?(can you)? ?tell me) about", "", q)
 

--- a/modules/gpt3module.py
+++ b/modules/gpt3module.py
@@ -75,7 +75,7 @@ class GPT3Module(Module):
             return Response()
 
         return Response(
-            confidence=2, callback=self.gpt3_chat, kwargs={ "self": self, "prompt": message}
+            confidence=2, callback=self.gpt3_chat, kwargs={"prompt": message}
         )
 
     def process_message_from_stampy(self, message: ServiceMessage) -> None:

--- a/modules/gpt3module.py
+++ b/modules/gpt3module.py
@@ -75,7 +75,7 @@ class GPT3Module(Module):
             return Response()
 
         return Response(
-            confidence=2, callback=self.gpt3_chat, args=[message], kwargs={}
+            confidence=2, callback=self.gpt3_chat, kwargs={ "self": self, "prompt": message}
         )
 
     def process_message_from_stampy(self, message: ServiceMessage) -> None:
@@ -165,7 +165,8 @@ class GPT3Module(Module):
         if self.openai and self.openai.is_channel_allowed(message):
             return self.openai.get_engine(message)
 
-    async def gpt3_chat(self, message: ServiceMessage) -> Response:
+    async def gpt3_chat(self, prompt: ServiceMessage) -> Response:
+        message: ServiceMessage = prompt
         """Ask GPT-3 what Stampy would say next in the chat log"""
         self.openai = cast(OpenAI, self.openai)
 

--- a/modules/module.py
+++ b/modules/module.py
@@ -106,7 +106,7 @@ class Response:
         text = self.text
         callback = self.callback.__name__ if self.callback else None
         args = self.args
-        kwargs = self.kwargs
+        kwargs = trim_kwargs(self.kwargs)
         module = str(self.module)
         why = self.why
         return (
@@ -333,3 +333,15 @@ class IntegrationTest(TypedDict):
     test_wait_time: float
     minimum_allowed_similarity: float
     result: Literal["PASSED", "FAILED", None]
+
+def trim_kwargs(kwargs: dict) -> dict:
+    unwanted = frozenset("prompt")
+    # Prompt should already be known by the user: #294
+    for item in unwanted:
+        if item in kwargs:
+            if hasattr(kwargs[item], "id"):
+                kwargs[item] = "id={}".format(kwargs[item].id)
+            else:
+                kwargs[item] = "<{}>".format(item)
+
+    return kwargs

--- a/modules/semanticanswers.py
+++ b/modules/semanticanswers.py
@@ -11,7 +11,7 @@ class SemanticAnswers(Module):
             return Response(
                 confidence=6,
                 callback=self.ask,
-                args=[text],
+                kwargs={ "self": self, "prompt": text},
                 why="It's a question, there might be a similar question in the database",
             )
         else:
@@ -20,8 +20,8 @@ class SemanticAnswers(Module):
     def __str__(self):
         return "Semantic Answers"
 
-    def ask(self, question):
-        q = question.lower().strip()
+    def ask(self, prompt: str):
+        q = prompt.lower().strip()
         url = (
             "https://stampy-nlp-t6p37v2uia-uw.a.run.app/api/search?query=%s"
             % urllib.parse.quote_plus(q)

--- a/modules/semanticanswers.py
+++ b/modules/semanticanswers.py
@@ -11,7 +11,7 @@ class SemanticAnswers(Module):
             return Response(
                 confidence=6,
                 callback=self.ask,
-                kwargs={ "self": self, "prompt": text},
+                kwargs={"prompt": text},
                 why="It's a question, there might be a similar question in the database",
             )
         else:

--- a/modules/why.py
+++ b/modules/why.py
@@ -24,14 +24,14 @@ class Why(Module):
                     return Response(
                         confidence=10,
                         callback=self.specific,
-                        args=[message],
+                        kwargs={ "self": self, "prompt": message},
                         why="A stamp owner wants to know why I said something.",
                     )
                 else:
                     return Response(
                         confidence=10,
                         callback=self.general,
-                        args=[message],
+                        kwargs={ "self": self, "prompt": message},
                         why="A stamp owner wants to know why I said something.",
                     )
             else:
@@ -54,7 +54,8 @@ class Why(Module):
                 return str(m.id)
         raise Exception("No message from stampy found")
 
-    async def specific(self, message: DiscordMessage) -> Response:
+    async def specific(self, prompt: DiscordMessage) -> Response:
+        message: DiscordMessage = prompt
         m_id = await self._get_message_about(message)
         messages = self._get_known_messages()
         if m_id not in messages:
@@ -68,7 +69,8 @@ class Why(Module):
             builder += f"{step}\n"
         return Response(confidence=10, text=builder, why="I was asked why I said something.")
 
-    async def general(self, message: DiscordMessage) -> Response:
+    async def general(self, prompt: DiscordMessage) -> Response:
+        message: DiscordMessage = prompt
         m_id = await self._get_message_about(message)
         messages = self._get_known_messages()
         if m_id not in messages:

--- a/modules/why.py
+++ b/modules/why.py
@@ -24,14 +24,14 @@ class Why(Module):
                     return Response(
                         confidence=10,
                         callback=self.specific,
-                        kwargs={ "self": self, "prompt": message},
+                        kwargs={"prompt": message},
                         why="A stamp owner wants to know why I said something.",
                     )
                 else:
                     return Response(
                         confidence=10,
                         callback=self.general,
-                        kwargs={ "self": self, "prompt": message},
+                        kwargs={"prompt": message},
                         why="A stamp owner wants to know why I said something.",
                     )
             else:

--- a/modules/wolfram.py
+++ b/modules/wolfram.py
@@ -35,14 +35,14 @@ class Wolfram(Module):
             return Response(
                 confidence=5,
                 callback=self.ask,
-                args=[text],
+                kwargs={ "self": self, "prompt": text},
                 why="It's a question, we might be able to answer it",
             )
         else:
             return Response(
                 confidence=1,
                 callback=self.ask,
-                args=[text],
+                kwargs={ "self": self, "prompt": text},
                 why="It's not a question but we might be able to look it up",
             )
 
@@ -59,7 +59,8 @@ class Wolfram(Module):
         else:
             return 8
 
-    def ask(self, question):
+    def ask(self, prompt: str):
+        question: str = prompt
         try:
             self.log.info(self.class_name, wolfram_alpha_question=question)
             question_escaped = urllib.parse.quote_plus(question.strip())

--- a/modules/wolfram.py
+++ b/modules/wolfram.py
@@ -35,14 +35,14 @@ class Wolfram(Module):
             return Response(
                 confidence=5,
                 callback=self.ask,
-                kwargs={ "self": self, "prompt": text},
+                kwargs={"prompt": text},
                 why="It's a question, we might be able to answer it",
             )
         else:
             return Response(
                 confidence=1,
                 callback=self.ask,
-                kwargs={ "self": self, "prompt": text},
+                kwargs={"prompt": text},
                 why="It's not a question but we might be able to look it up",
             )
 

--- a/servicemodules/discord.py
+++ b/servicemodules/discord.py
@@ -19,7 +19,7 @@ from config import (
     youtube_api_key,
     bot_private_channel_id,
 )
-from modules.module import Response
+from modules.module import Response, trim_kwargs
 from servicemodules import discordConstants
 from utilities import (
     Utilities,
@@ -169,6 +169,8 @@ class DiscordHandler:
 
                     response.text = limit_text_and_notify(response, why_traceback)
 
+                    response = trim_kwargs(response.kwargs)
+
                     why_traceback.append(
                         f"I asked the {module} module, and it responded with: {response}"
                     )
@@ -183,10 +185,11 @@ class DiscordHandler:
                     if response.callback:
                         args_string = ", ".join([a.__repr__() for a in response.args])
                         if response.kwargs:
+                            cleaned_items = trim_kwargs(response.kwargs)
                             args_string += ", " + ", ".join(
                                 [
                                     f"{k}={v.__repr__()}"
-                                    for k, v in response.kwargs.items()
+                                    for k, v in cleaned_items
                                 ]
                             )
                     log.info(


### PR DESCRIPTION
I'm trying to change the way that tracebacks work so that callbacks don't reprint the original prompt. This involves giving arguments to the callbacks in such a way that the traceback collector will know to remove them (I decided to try to leave the message ID if there is one, otherwise just leaving `<prompt>`).

This is my attempted solution, which makes the keyword argument `prompt` something that the traceback module removes. However **it doesn't work**. Every module gets asked the question but no responses are ever returned, not even the initial once's inviting a traceback. (I notice that the Sentience module prints "Confused response sent") I'd love it if someone could point out what I'm doing wrong, because I even tried redoing this from scratch and got the same result. Also if anyone knows how to make Python print a stack trace for all threads on demand I'd like to know.

would help #294 