### PR TITLE
merge ROBMILES_DEFAULTS and NOT_ROB_SERVER to IS_ROB_SERVER

### DIFF
--- a/.github/workflows/deploy-to-production-server.yml
+++ b/.github/workflows/deploy-to-production-server.yml
@@ -78,7 +78,7 @@ jobs:
             export WOLFRAM_TOKEN=$(cat ~/.wolframtoken);
             export CODA_API_TOKEN=$(cat ~/.codatoken);
 
-            export ROBMILES_DEFAULTS="TRUE"
+            export IS_ROB_SERVER="TRUE"
 
             cd ~/stampy
             conda activate stampy

--- a/.github/workflows/unit-test-pull-request.yml
+++ b/.github/workflows/unit-test-pull-request.yml
@@ -8,7 +8,7 @@ on:
       - '*'
 env:
   ENVIRONMENT_TYPE: 'development'
-  ROBMILES_DEFAULTS: 'TRUE'
+  IS_ROB_SERVER: 'TRUE'
   DISCORD_TOKEN: 'testing'
   DISCORD_GUILD: 'testing'
   YOUTUBE_API_KEY: 'testing'

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Not required:
 - `STOP_ON_ERROR`: Dockerfile/`runstampy` only, unset `BOT_REBOOT` only. If defined, will only restart Stampy when he gets told to reboot, returning exit code 42. Any other exit code will cause the script to just stop.
 - `BE_SHY`: Stamp won't respond when the message isn't specifically to him.
 - `CHANNEL_WHITELIST`: channels Stampy is allowed to respond to messages in
-- `NOT_ROB_SERVER`: If `True`, Rob Miles server-specific stuff is disabled. Servers other than Rob Miles Discord Server and Stampy Test Server should set it to `1`. Otherwise some errors are likely to occur.
+- `IS_ROB_SERVER`: If defined, Rob Miles server-specific stuff is enabled. Servers other than Rob Miles Discord Server and Stampy Test Server should not enable it, Otherwise some errors are likely to occur.
 
 Specific modules (excluding LLM stuff):
 

--- a/config.py
+++ b/config.py
@@ -159,8 +159,8 @@ llm_prompt: str
 be_shy: bool
 channel_whitelist: Optional[frozenset[str]]
 
-robmiles_defaults = getenv_bool("ROBMILES_DEFAULTS")
-if robmiles_defaults:
+is_rob_server = getenv_bool("IS_ROB_SERVER")
+if is_rob_server:
     # use robmiles server defaults
     print("Using settings for the Rob Miles Discord server")
     discord_guild = {
@@ -262,8 +262,6 @@ wolfram_token: Optional[str] = getenv("WOLFRAM_TOKEN", default=None)
 slack_app_token: Optional[str] = getenv("SLACK_APP_TOKEN", default=None)
 slack_bot_token: Optional[str] = getenv("SLACK_BOT_TOKEN", default=None)
 
-not_rob_server = getenv_bool("NOT_ROB_SERVER")
-is_rob_server = not not_rob_server
 
 
 # VARIABLE VALIDATION

--- a/scripts/update-stampy.sh
+++ b/scripts/update-stampy.sh
@@ -34,7 +34,7 @@ export YOUTUBE_API_KEY="$(cat ~/.youtubeapikey)"
 export CLIENT_SECRET_PATH="$(cat ~/.clientsecretpath)"
 export WOLFRAM_TOKEN=$(cat ~/.wolframtoken);
 
-export ROBMILES_DEFAULTS="TRUE"
+export IS_ROB_SERVER="TRUE"
 
 cd ~/stampy
 conda activate stampy


### PR DESCRIPTION
Make a new variable, `IS_ROB_SERVER`, covering behavior of `ROBMILES_DEFAULTS` and replacing `NOT_ROB_SERVER`.

I wanted to do this because Rob's server variables can be set in the GitHub workflows (as seen in this commit), while new people setting up Stampy instances would get bit by not setting `NOT_ROB_SERVER`.